### PR TITLE
Don't override callback_url Attempt to correct #28

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -33,10 +33,6 @@ module OmniAuth
         ::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options))
       end
 
-      def callback_url
-        full_host + script_name + callback_path
-      end
-
       credentials do
         hash = {'token' => access_token.token}
         hash.merge!('refresh_token' => access_token.refresh_token) if access_token.expires? && access_token.refresh_token


### PR DESCRIPTION
I hope nobody minds me issuing this PR. It bit us pretty hard and would be great to get it merged into master!

Overridden method discarded the query_string