### PR TITLE
Fixes a bug where the included hook isn't run.

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -14,6 +14,10 @@ module OmniAuth
     class OAuth2
       include OmniAuth::Strategy
 
+      def self.inherited(subclass)
+        OmniAuth::Strategy.included(subclass)
+      end
+
       args [:client_id, :client_secret]
 
       option :client_id, nil

--- a/spec/omniauth/strategies/oauth2_spec.rb
+++ b/spec/omniauth/strategies/oauth2_spec.rb
@@ -16,6 +16,15 @@ describe OmniAuth::Strategies::OAuth2 do
     OmniAuth.config.test_mode = false
   end
 
+  describe "Subclassing Behavior" do
+    subject { fresh_strategy }
+
+    it "performs the OmniAuth::Strategy included hook" do
+      expect(OmniAuth.strategies).to include(OmniAuth::Strategies::OAuth2)
+      expect(OmniAuth.strategies).to include(subject)
+    end
+  end
+
   describe "#client" do
     subject { fresh_strategy }
 


### PR DESCRIPTION
Subclassing doesn't run the included hook of OmniAuth::Strategy on the
subclass. This is causing some issues with OmniAuth.