### PR TITLE
fix broken backward compatibility (callback_url)

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -29,6 +29,7 @@ module OmniAuth
       option :token_options, []
       option :auth_token_params, {}
       option :provider_ignores_state, false
+      option :include_query_string, false
 
       attr_accessor :access_token
 
@@ -86,7 +87,8 @@ module OmniAuth
 
       def build_access_token
         verifier = request.params["code"]
-        client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(token_params.to_hash(:symbolize_keys => true)), deep_symbolize(options.auth_token_params))
+        url = options.include_query_string ? callback_url : (full_host + script_name + callback_path)
+        client.auth_code.get_token(verifier, {:redirect_uri => url}.merge(token_params.to_hash(:symbolize_keys => true)), deep_symbolize(options.auth_token_params))
       end
 
       def deep_symbolize(options)


### PR DESCRIPTION
This is a fix for broken backward compatibility which was introduced with pull request https://github.com/intridea/omniauth-oauth2/pull/70

Some OAuth2 providers (like `omniauth-google-oauth2`) fails if `callback_url` is not the same in `callback_phase` and `request_phase`. 
Prior to version 1.4.0 `callback_url` was overridden (and `query_string` was discarded) which was problem for @agrobbin and some others.
This pull request propose fix with new option `include_query_string` (by default set to false, to preserve backward compatibility) and those who needs full callback_url (with query_string) in the will set this option to true: `include_query_string: true`

