### PR TITLE
Multiple origins

### DIFF
--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -55,7 +55,11 @@ module OmniAuth
           @env ||= {}
           @env["rack.session"] ||= {}
         end
-        session["omniauth.state"] = params[:state]
+        session["omniauth.states"] ||= []
+        session["omniauth.states"] << params[:state]
+
+        session["omniauth.state_origins"] ||= {}
+        session["omniauth.state_origins"][params[:state]] = session['omniauth.origin']
         params
       end
 
@@ -63,15 +67,19 @@ module OmniAuth
         options.token_params.merge(options_for("token"))
       end
 
-      def callback_phase # rubocop:disable AbcSize, CyclomaticComplexity, MethodLength, PerceivedComplexity
+      def callback_phase
         error = request.params["error_reason"] || request.params["error"]
         if error
           fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
-        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
+        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || session["omniauth.states"].empty? || !session["omniauth.states"].include?(request.params["state"]))
           fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
         else
           self.access_token = build_access_token
           self.access_token = access_token.refresh! if access_token.expired?
+
+          if session['omniauth.state_origins'] && session['omniauth.state_origins'][request.params['state']]
+            env['omniauth.origin'] = session['omniauth.state_origins'][request.params['state']]
+          end
           super
         end
       rescue ::OAuth2::Error, CallbackError => e

--- a/lib/omniauth/strategies/oauth2.rb
+++ b/lib/omniauth/strategies/oauth2.rb
@@ -67,7 +67,7 @@ module OmniAuth
         options.token_params.merge(options_for("token"))
       end
 
-      def callback_phase
+      def callback_phase # rubocop:disable AbcSize, CyclomaticComplexity, MethodLength, PerceivedComplexity
         error = request.params["error_reason"] || request.params["error"]
         if error
           fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))


### PR DESCRIPTION
Consider a scenario where you only allow your users to authenticate against a single oauth2 provider such as Google.  In these scenarios it's common not to have a login page and just immediately attempt authentication against the oauth2 provider.  If the user starts up his browser and has multiple tabs of your application open, all these tabs redirects to the provider login screen.  If the user then signs in on each tab he gets a CSRF error on your application because this gem only allows one `state` parameter in the session.  Furthermore it doesn't redirect back to the origin correctly because it only stores one `origin` as well.  This pull request stores multiple `state` parameters in the session and an `origin` for each of the `states`.